### PR TITLE
Update utils.h: make trim a static function

### DIFF
--- a/include/pfnet/utils.h
+++ b/include/pfnet/utils.h
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <ctype.h>
 
-char* trim(char *s) {
+static char* trim(char *s) {
   /* Trims string inplace. */
   
   char *ptr;


### PR DESCRIPTION
The trim function is defined in a header file.  This can cause linker errors if two separate source files include `utils.h`.  The solution is to make the function `static`, which means it will only be visible to the compilation of the source file and not the linker.